### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ In your JavaScript, use the require function to get a reference:
 var makerjs = require('makerjs');
 ```
 
+### To use via CDN
+
+Add a script tag to your HTML:
+```
+<script src="https://cdn.jsdelivr.net/npm/makerjs@0.9.74/target/js/browser.maker.js"></script>
+```
+
+In your JavaScript, use the require function to get a reference:
+```
+var makerjs = require('makerjs');
+```
+
 ### To use in Node.js
 
 To depend on Maker.js, run this from the command line:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,15 @@ var makerjs = require('makerjs');
 
 Add a script tag to your HTML:
 ```
-<script src="https://cdn.jsdelivr.net/npm/makerjs@0.9.74/target/js/browser.maker.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/makerjs@0/target/js/browser.maker.js"></script>
+```
+To work with Bezier Curves, you will also need a copy of [Bezier.js by Pomax](http://pomax.github.io/bezierjs/)
+```
+<script src="https://cdn.jsdelivr.net/npm/bezier-js@2/bezier.js"></script>
+```
+To work with fonts, you will need both Bezier.js(above) and a copy of [Opentype.js by Frederik De Bleser](https://github.com/nodebox/opentype.js)
+```
+<script src="https://cdn.jsdelivr.net/npm/opentype.js@0/dist/opentype.js"></script>
 ```
 
 In your JavaScript, use the require function to get a reference:


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/makerjs) to your readme, so that people can use files directly without downloading them. jsDelivr is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage.