### PR TITLE
setParam fix for number input

### DIFF
--- a/packages/playground/src/playground.ts
+++ b/packages/playground/src/playground.ts
@@ -159,12 +159,12 @@
                             "value": attrs.value,
                             "onfocus": 'if (MakerJsPlayground.isSmallDevice()) { MakerJsPlayground.activateParam(this.parentElement); }',
                             "onblur": 'if (MakerJsPlayground.isSmallDevice()) { MakerJsPlayground.deActivateParam(this.parentElement, 0); }',
-                            "onchange": 'MakerJsPlayground.setParam(' + i + ', makerjs.round(this.value, .001))'
+                            "onchange": 'MakerJsPlayground.setParam(' + i + ', makerjs.round(this.valueAsNumber, .001))'
                         };
 
                         var formAttrs = {
                             "action": 'javascript:void(0);',
-                            "onsubmit": 'MakerJsPlayground.setParam(' + i + ', makerjs.round(this.elements[0].value, .001))'
+                            "onsubmit": 'MakerJsPlayground.setParam(' + i + ', makerjs.round(this.elements[0].valueAsNumber, .001))'
                         };
 
                         numberBox = new makerjs.exporter.XmlTag('form', formAttrs);


### PR DESCRIPTION
while changing the params with the slider works perfectly, changing the params by toggling the slider with the mouse the arrow keys or directly setting typing a value in the input field yields a wrong result.

Replacing `value` with `valueAsNumber` fixes the issue

Steps to reproduce
* Open https://maker.js.org/playground/?script=Ring in a browser
* Use the silder to change the outer radius (works as expected)
* Select the value and use the arrow keys to change the value (the result is wrong)