### PR TITLE
Dragging over the edge of the canvas breaks drag&drop

### DIFF
--- a/packages/playground/src/pointer.ts
+++ b/packages/playground/src/pointer.ts
@@ -44,6 +44,10 @@ module Pointer {
     }
 
     function distanceBetweenCurrent2Points(all: IPointer[]) {
+        if (all[0].current == null || all[1].current == null)
+        {
+            return null;
+        }    
         return makerjs.measure.pointDistance(all[0].current.fromCanvas, all[1].current.fromCanvas);
     }
 

--- a/packages/playground/src/pointer.ts
+++ b/packages/playground/src/pointer.ts
@@ -44,10 +44,9 @@ module Pointer {
     }
 
     function distanceBetweenCurrent2Points(all: IPointer[]) {
-        if (all[0].current == null || all[1].current == null)
-        {
+        if (!all[0].current || !all[1].current) {
             return null;
-        }    
+        }
         return makerjs.measure.pointDistance(all[0].current.fromCanvas, all[1].current.fromCanvas);
     }
 


### PR DESCRIPTION
* Left click the mouse on the canvas and start dragging (the model moves around)
* Drag over the edge of the canvas and release the mouse button
* Move your mouse back over the canvas (the model still moves around
* Now left click again
* The following exception gets thrown and drag&drop is broken until you reload the window

```
Uncaught TypeError: Cannot read property 'current' of undefined
    at distanceBetweenCurrent2Points (pointer.ts:47)
    at Manager.viewPointerMove (pointer.ts:314)
    at HTMLDivElement.<anonymous> (pointer.ts:91)
distanceBetweenCurrent2Points @ pointer.ts:47
Manager.viewPointerMove @ pointer.ts:314
(anonymous) @ pointer.ts:91
```