### PR TITLE
add a bunch of basic intersection tests

### DIFF
--- a/packages/maker.js/test/intersection.js
+++ b/packages/maker.js/test/intersection.js
@@ -56,6 +56,97 @@ describe('Path Intersection', function () {
         assert.equal(int.path2Angles.sort((a, b) => b - a)[1], 45);
         assert.ok(int.intersectionPoints);
         assert.equal(int.intersectionPoints.length, 2);
+    });
 
+    it('should intersect overlapping circles', function() {
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 1], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.ok(int);
+        assert.ok(int.path2Angles);
+        assert.equal(int.path2Angles.length, 2);
+        assert.equal(int.path2Angles.sort((a, b) => b - a)[0], 330);
+        assert.equal(int.path2Angles.sort((a, b) => b - a)[1], 210);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 2);
+    })
+
+    it('should not intersect tangent circles if excludeTangents = true', function() {
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 2], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2, {excludeTangents: true});
+
+        assert.equal(int, null);
+    })
+
+    it('should intersect tangent circles at one angle, one point', function() {
+
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 2], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.ok(int);
+        assert.ok(int.path2Angles);
+        assert.equal(int.path2Angles.length, 1);
+        assert.equal(int.path2Angles.sort((a, b) => b - a)[0], 270);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 1);
+    })
+
+    it('should not interesect circle inside circle', function () {
+
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 0], 0.5);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.equal(int, null);
+    });
+
+    it('should not interesect circle on circle', function () {
+
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 0], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.equal(int, null);
+    });
+
+    it('should intersect two crossing lines', function() {
+        var line1 = new makerjs.paths.Line([0, 0], [1, 1]);
+        var line2 = new makerjs.paths.Line([0, 1], [1, 0]);
+
+        var int = makerjs.path.intersection(line1, line2);
+
+        assert.ok(int);
+        assert.equal(int.path2Angles, null);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 1);
+    });
+
+    it('should not intersect two non-intersecting lines', function() {
+        var line1 = new makerjs.paths.Line([0, 0], [1, 1]);
+        var line2 = new makerjs.paths.Line([0, 1], [2, 2]);
+
+        var int = makerjs.path.intersection(line1, line2);
+
+        assert.equal(int, null);
+    });
+
+    it('should intersect two lines that touch at their origins', function() {
+        var line1 = new makerjs.paths.Line([0, 0], [1, 2]);
+        var line2 = new makerjs.paths.Line([0, 0], [1, 1]);
+
+        var int = makerjs.path.intersection(line1, line2);
+
+        assert.ok(int);
+        assert.equal(int.path2Angles, null);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 1);
     });
 });


### PR DESCRIPTION
Tried to add some more unittests for intersection in preparation for trying to reduce the usage of round() in the logic.

```
> makerjs@0.14.0 test /Users/blackmad/Dropbox/Code/maker.js/packages/maker.js
> mocha --timeout 15000



  Angle
    ✓ should normalize an angle
    ✓ should normalize a negative revolution
    ✓ should find end of arc past start
    ✓ should find end of arc past start - all negative
    ✓ should find end of arc past start - end negative
    ✓ should find arc span
    ✓ should find arcSpan when end is less than start
    ✓ should find arcSpan when angles are mixed
    ✓ should find arcSpan when angles are mixed2
    ✓ should find arcSpan when angles are negative
    ✓ should find arcSpan when angles are negative revolution

  Beziers
    ✓ should export SVG of a bezier curve with offset origin

  Chains
    ✓ should find a chain of 2 links
    ✓ should find an endless chain in a square
    ✓ should find a zero joint
    ✓ should find a 90 joint
    ✓ should find a 45 joint with a line at start of an arc
    ✓ should find a 45 joint with a line at end of an arc
    ✓ should find a zero joint with a line at end of an arc
    ✓ should find a zero joint with a line at start of an arc
    ✓ should find a 180 joint with two arcs
    ✓ should find outlines around a shape (5532ms)

  Combine
    ✓ should union 2 squares
    ✓ should trim dead ends

  Core
    ✓ should round 1.005 to 1.01
    ✓ should round 1.001 to 1
    ✓ should add property with extendObject
    ✓ should change property with extendObject
    Type checks
      ✓ should validate with isNumber
      ✓ should not validate with isNumber
      ✓ should round to a number
      ✓ should validate with isPoint
      ✓ should not validate with isPoint
      ✓ should validate with isPath
      ✓ should not validate with isPath
      ✓ should validate with isPathLine
      ✓ should not validate with isPathLine
      ✓ should validate with isPathCircle
      ✓ should not validate with isPathCircle
      ✓ should validate with isPathArc
      ✓ should not validate with isPathArc
      ✓ should validate with isModel
      ✓ should not validate with isModel

  Path Intersection
    ✓ should intersect an arc and a circle
    ✓ should intersect an arc and a line at one point
    ✓ should intersect a line and a circle in 2 points
    ✓ should intersect overlapping circles
    ✓ should not intersect tangent circles if excludeTangents = true
    ✓ should intersect tangent circles at one angle, one point
    ✓ should not interesect circle inside circle
    ✓ should not interesect circle on circle
    ✓ should intersect two crossing lines
    ✓ should not intersect two non-intersecting lines
    ✓ should intersect two lines that touch at their origins

  jscad
    ✓ can convert to jscad CAG (41ms)
    ✓ can reach 100% progress for jscad CAG subtractions (54ms)

  Measure
    ✓ should find number between when not exclusive
    ✓ should not find number between when exclusive
    ✓ should find angle between when not exclusive
    ✓ should not find angle between when exclusive
    ✓ should find same center for bounding hexagon and a circle
    ✓ should find same center for bounding hexagon and a square
    ✓ should find same center for bounding hexagon and an offset circle
    ✓ should find same center for bounding hexagon and an offset square
    ✓ should find overlapping arcs
    ✓ should find overlapping lines
    ✓ should find equal slopes
    ✓ should find point on a slope
    ✓ should find point on a circle
    ✓ should find point on a path

  Outline
    ✓ should inset twice (377ms)
    ✓ should bevel (317ms)

  Paths
    ✓ should create a Line
    ✓ should create a Circle
    ✓ should create an Arc

  Export SVG
    ✓ should export without a closing tag
    ✓ should export with a closing tag
    ✓ should export cssStyle


  78 passing (6s)

lerna success run Ran npm script 'test' in 1 package in 7.0s:
lerna success - makerjs
```