### PR TITLE
Less round in intersect

### DIFF
--- a/packages/maker.js/src/core/intersect.ts
+++ b/packages/maker.js/src/core/intersect.ts
@@ -340,20 +340,25 @@ namespace MakerJs.path {
 
         } else {
 
-            function intersectionBetweenEndpoints(x: number, angleOfX: number) {
-                if (measure.isBetween(round(x), round(clonedLine.origin[0]), round(clonedLine.end[0]), options.excludeTangents)) {
-                    anglesOfIntersection.push(unRotate(angleOfX));
-                }
-            }
-
             //find angle where line intersects
             var intersectRadians = Math.asin(lineY / radius);
             var intersectDegrees = angle.toDegrees(intersectRadians);
+            var roundedIntersectDegrees = round(intersectDegrees);
 
             //line may intersect in 2 places
             var intersectX = Math.cos(intersectRadians) * radius;
-            intersectionBetweenEndpoints(-intersectX, 180 - intersectDegrees);
-            intersectionBetweenEndpoints(intersectX, intersectDegrees);
+            const roundedIntersectX = round(intersectX)
+
+            var roundedStartX = round(clonedLine.origin[0]);
+            var roundedEndX = round(clonedLine.end[0]);
+
+            if (measure.isBetween(-roundedIntersectX, roundedStartX, roundedEndX, options.excludeTangents)) {
+                anglesOfIntersection.push(unRotate(180 - roundedIntersectDegrees));
+            }
+            
+            if (measure.isBetween(roundedIntersectX, roundedStartX, roundedEndX, options.excludeTangents)) {
+                anglesOfIntersection.push(unRotate(roundedIntersectDegrees));
+            }
         }
 
         if (anglesOfIntersection.length > 0) {
@@ -401,7 +406,7 @@ namespace MakerJs.path {
         var x = c2.origin[0];
 
         //see if circles are tangent interior on left side
-        if (round(c2.radius - x - c1.radius) == 0) {
+        if (almostEqual(c2.radius - x - c1.radius, 0)) {
 
             if (options.excludeTangents) {
                 return null;
@@ -411,7 +416,7 @@ namespace MakerJs.path {
         }
 
         //see if circles are tangent interior on right side
-        if (round(c2.radius + x - c1.radius) == 0) {
+        if (almostEqual(c2.radius + x - c1.radius, 0)) {
 
             if (options.excludeTangents) {
                 return null;
@@ -421,7 +426,7 @@ namespace MakerJs.path {
         }
 
         //see if circles are tangent exterior
-        if (round(x - c2.radius - c1.radius) == 0) {
+        if (almostEqual(x - c2.radius - c1.radius, 0)) {
 
             if (options.excludeTangents) {
                 return null;
@@ -430,18 +435,19 @@ namespace MakerJs.path {
             return [[unRotate(0)], [unRotate(180)]];
         }
 
+        var xMinusC2RadiusRounded = round(x - c2.radius)
         //see if c2 is outside of c1
-        if (round(x - c2.radius) > c1.radius) {
+        if (xMinusC2RadiusRounded > c1.radius) {
+            return null;
+        }
+
+        //see if c1 is within c2
+        if (xMinusC2RadiusRounded < -c1.radius) {
             return null;
         }
 
         //see if c2 is within c1
         if (round(x + c2.radius) < c1.radius) {
-            return null;
-        }
-
-        //see if c1 is within c2
-        if (round(x - c2.radius) < -c1.radius) {
             return null;
         }
 

--- a/packages/maker.js/src/core/maker.ts
+++ b/packages/maker.js/src/core/maker.ts
@@ -112,6 +112,18 @@ namespace MakerJs {
         return split(s, '.');
     }
 
+   /*
+    * Find out if two numbers are almost equal
+    * 
+    * @param a First number.
+    * @param b Second number.
+    * @ param  epsilon maximum difference between a and b
+    * @returns true if numbers are almost equal
+    */
+   export function almostEqual(a: number, b: number, epsilon: number = .000001): boolean {
+       return Math.abs(a - b) < epsilon
+   }
+
     /**
      * Numeric rounding
      * 

--- a/packages/maker.js/test/intersection.js
+++ b/packages/maker.js/test/intersection.js
@@ -56,6 +56,97 @@ describe('Path Intersection', function () {
         assert.equal(int.path2Angles.sort((a, b) => b - a)[1], 45);
         assert.ok(int.intersectionPoints);
         assert.equal(int.intersectionPoints.length, 2);
+    });
 
+    it('should intersect overlapping circles', function() {
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 1], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.ok(int);
+        assert.ok(int.path2Angles);
+        assert.equal(int.path2Angles.length, 2);
+        assert.equal(int.path2Angles.sort((a, b) => b - a)[0], 330);
+        assert.equal(int.path2Angles.sort((a, b) => b - a)[1], 210);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 2);
+    })
+
+    it('should not intersect tangent circles if excludeTangents = true', function() {
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 2], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2, {excludeTangents: true});
+
+        assert.equal(int, null);
+    })
+
+    it('should intersect tangent circles at one angle, one point', function() {
+
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 2], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.ok(int);
+        assert.ok(int.path2Angles);
+        assert.equal(int.path2Angles.length, 1);
+        assert.equal(int.path2Angles.sort((a, b) => b - a)[0], 270);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 1);
+    })
+
+    it('should not interesect circle inside circle', function () {
+
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 0], 0.5);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.equal(int, null);
+    });
+
+    it('should not interesect circle on circle', function () {
+
+        var circle1 = new makerjs.paths.Circle([0, 0], 1);
+        var circle2 = new makerjs.paths.Circle([0, 0], 1);
+
+        var int = makerjs.path.intersection(circle1, circle2);
+
+        assert.equal(int, null);
+    });
+
+    it('should intersect two crossing lines', function() {
+        var line1 = new makerjs.paths.Line([0, 0], [1, 1]);
+        var line2 = new makerjs.paths.Line([0, 1], [1, 0]);
+
+        var int = makerjs.path.intersection(line1, line2);
+
+        assert.ok(int);
+        assert.equal(int.path2Angles, null);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 1);
+    });
+
+    it('should not intersect two non-intersecting lines', function() {
+        var line1 = new makerjs.paths.Line([0, 0], [1, 1]);
+        var line2 = new makerjs.paths.Line([0, 1], [2, 2]);
+
+        var int = makerjs.path.intersection(line1, line2);
+
+        assert.equal(int, null);
+    });
+
+    it('should intersect two lines that touch at their origins', function() {
+        var line1 = new makerjs.paths.Line([0, 0], [1, 2]);
+        var line2 = new makerjs.paths.Line([0, 0], [1, 1]);
+
+        var int = makerjs.path.intersection(line1, line2);
+
+        assert.ok(int);
+        assert.equal(int.path2Angles, null);
+        assert.ok(int.intersectionPoints);
+        assert.equal(int.intersectionPoints.length, 1);
     });
 });


### PR DESCRIPTION
This change attempts to reduce the use of makerjs.round in intersection, it does this by memoizing some rounds, and moving others to be near-equal checks.