### PR TITLE
call endModel for '0' to fix malformed svg bug

### DIFF
--- a/packages/maker.js/src/core/svg.ts
+++ b/packages/maker.js/src/core/svg.ts
@@ -707,6 +707,8 @@ namespace MakerJs.exporter {
                 layerGroup.innerTextEscaped = true;
                 append(layerGroup.toString());
             }
+
+            endModel(modelToExport);
         }
 
         const captionTags = captions.map(caption => {

--- a/packages/maker.js/test/svg.js
+++ b/packages/maker.js/test/svg.js
@@ -37,4 +37,19 @@ describe('Export SVG', function () {
         assert.ok(svg.indexOf('style="style3"') > 0);
     });
 
+    it('should export with all <g> tags closed', function () {
+        var svg = makerjs.exporter.toSVG(model, { useSvgPathOnly: false });
+        var result, openTags = [], closeTags = [];
+        var regex = /<g/gi;
+        while ( (result = regex.exec(svg)) ) {
+          openTags.push(result.index);
+        }
+        regex = /<\/g/gi;
+        while ( (result = regex.exec(svg)) ) {
+          closeTags.push(result.index);
+        }
+        assert.ok(openTags.length > 0);
+        assert.ok(closeTags.length == openTags.length);
+    });
+
 });


### PR DESCRIPTION
When you call `makerjs.exporter.toSVG()` and specify `useSvgPathOnly: false` the resulting svg was malformed.

```javascript
var makerjs = require('makerjs');
var square = new makerjs.models.Square(100);
var svg = makerjs.exporter.toSVG(square, {useSvgPathOnly: false});
console.log(svg);
```

* Before
```xml
<?xml version="1.0" encoding="UTF-8"?>
<svg width="100" height="100" viewBox="0 0 100 100">
   <g id="svgGroup" stroke-linecap="round" fill-rule="evenodd" font-size="9pt" stroke="#000" stroke-width="0.25mm" fill="none" style="stroke:#000;stroke-width:0.25mm;fill:none">
      <g id="0">
         <line id="ShapeLine1" data-route="[&quot;paths&quot;,&quot;ShapeLine1&quot;]" x1="0" y1="100" x2="100" y2="100" vector-effect="non-scaling-stroke" />
         <line id="ShapeLine2" data-route="[&quot;paths&quot;,&quot;ShapeLine2&quot;]" x1="100" y1="100" x2="100" y2="0" vector-effect="non-scaling-stroke" />
         <line id="ShapeLine3" data-route="[&quot;paths&quot;,&quot;ShapeLine3&quot;]" x1="100" y1="0" x2="0" y2="0" vector-effect="non-scaling-stroke" />
         <line id="ShapeLine4" data-route="[&quot;paths&quot;,&quot;ShapeLine4&quot;]" x1="0" y1="0" x2="0" y2="100" vector-effect="non-scaling-stroke" />
   </g>
</svg>
```

* After
```xml
<?xml version="1.0" encoding="UTF-8"?>
<svg width="100" height="100" viewBox="0 0 100 100">
   <g id="svgGroup" stroke-linecap="round" fill-rule="evenodd" font-size="9pt" stroke="#000" stroke-width="0.25mm" fill="none" style="stroke:#000;stroke-width:0.25mm;fill:none">
      <g id="0">
         <line id="ShapeLine1" data-route="[&quot;paths&quot;,&quot;ShapeLine1&quot;]" x1="0" y1="100" x2="100" y2="100" vector-effect="non-scaling-stroke" />
         <line id="ShapeLine2" data-route="[&quot;paths&quot;,&quot;ShapeLine2&quot;]" x1="100" y1="100" x2="100" y2="0" vector-effect="non-scaling-stroke" />
         <line id="ShapeLine3" data-route="[&quot;paths&quot;,&quot;ShapeLine3&quot;]" x1="100" y1="0" x2="0" y2="0" vector-effect="non-scaling-stroke" />
         <line id="ShapeLine4" data-route="[&quot;paths&quot;,&quot;ShapeLine4&quot;]" x1="0" y1="0" x2="0" y2="100" vector-effect="non-scaling-stroke" />
      </g>
   </g>
</svg>
```