### PR TITLE
add 'xmlns' as a default svg attribute

### DIFF
--- a/packages/maker.js/src/core/svg.ts
+++ b/packages/maker.js/src/core/svg.ts
@@ -477,7 +477,7 @@ namespace MakerJs.exporter {
 
         //begin svg output
 
-        var svgAttrs: IXmlTagAttrs;
+        var svgAttrs: IXmlTagAttrs = {};
 
         if (size && opts.viewBox) {
             var width = round(size.width * opts.scale, opts.accuracy);
@@ -493,7 +493,8 @@ namespace MakerJs.exporter {
             };
         }
 
-        var svgTag = new XmlTag('svg', <IXmlTagAttrs>extendObject(svgAttrs || {}, opts.svgAttrs));
+        svgAttrs["xmlns"] = "http://www.w3.org/2000/svg";
+        var svgTag = new XmlTag('svg', <IXmlTagAttrs>extendObject(svgAttrs, opts.svgAttrs));
 
         append(svgTag.getOpeningTag(false));
 

--- a/packages/maker.js/test/svg.js
+++ b/packages/maker.js/test/svg.js
@@ -37,4 +37,9 @@ describe('Export SVG', function () {
         assert.ok(svg.indexOf('style="style3"') > 0);
     });
 
+    it('should export with xmlns by default', function () {
+        var svg = makerjs.exporter.toSVG(model);
+        assert.ok(svg.indexOf('xmlns="http://www.w3.org/2000/svg"') > 0);
+    });
+
 });


### PR DESCRIPTION
When you call `makerjs.exporter.toSVG()` and specify `useSvgPathOnly: false` the resulting svg by default does not have a `xmlns` attribute.  This causes the browser to display it as XML (not SVG).

Without this PR, you can add it as an `svgAttrs` in the `exportOptions`, but it seems like a sensible default.

```javascript
{
  useSvgPathOnly: false,
  svgAttrs: {
    xmlns: "http://www.w3.org/2000/svg"
  }
}
```

```javascript
var makerjs = require('makerjs');
var square = new makerjs.models.Square(100);
var svg = makerjs.exporter.toSVG(square, {useSvgPathOnly: false});
console.log(svg);
```

* Before
```xml
<?xml version="1.0" encoding="UTF-8"?>
<svg width="100" height="100" viewBox="0 0 100 100">
   <g id="svgGroup" stroke-linecap="round" fill-rule="evenodd" font-size="9pt" stroke="#000" stroke-width="0.25mm" fill="none" style="stroke:#000;stroke-width:0.25mm;fill:none">
      ...
   </g>
</svg>
```

* After  
```xml
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
   <g id="svgGroup" stroke-linecap="round" fill-rule="evenodd" font-size="9pt" stroke="#000" stroke-width="0.25mm" fill="none" style="stroke:#000;stroke-width:0.25mm;fill:none">
      ...
   </g>
</svg>
```