### PR TITLE
DXF captions styling

### DIFF
--- a/packages/maker.js/src/core/dxf.ts
+++ b/packages/maker.js/src/core/dxf.ts
@@ -148,13 +148,15 @@ namespace MakerJs.exporter {
         }
 
         function text(caption: ICaption & { layer?: string }) {
+            const layerId = defaultLayer(null, caption.layer);
+            const layerOptions = colorLayerOptions(layerId);
             const center = point.middle(caption.anchor);
             const textEntity: DxfParser.EntityTEXT = {
                 type: "TEXT",
                 startPoint: appendVertex(center, null),
                 endPoint: appendVertex(center, null),
-                layer: defaultLayer(null, caption.layer),
-                textHeight: opts.fontSize,
+                layer: layerId,
+                textHeight: (layerOptions && layerOptions.fontSize) || opts.fontSize,
                 text: caption.text,
                 halign: 4, // Middle
                 valign: 0, // Baseline
@@ -516,6 +518,11 @@ namespace MakerJs.exporter {
          * DXF layer color.
          */
         color: number
+
+        /**
+         * Text size for TEXT entities.
+         */
+        fontSize?: number;
     }
 
     /**


### PR DESCRIPTION
## What does it do?
* Currently you specify the `fontSize` at the top DXF export lever.  This allows you to override the `fontSize` for a `caption`
* Fixes #422 

## Example
```javascript
var exportOptions = {
  fontSize: 4,  // default for drawing
  layerOptions: {
    big_square: {
      fontSize: 8,  // override
    }
  }
}
var model = {};

makerjs
            .$(new makerjs.models.Square(100))
            .layer('big_square')
            .addCaption('big fold here', [0, 0], [100, 100])
            .addTo(model, 'big_square');
makerjs
            .$(new makerjs.models.Square(50))
            .layer('little_square')
            .addCaption('little fold here', [0, 0], [50, 50])
            .addTo(model, 'little_square');
```

## Result
* The `big_square` caption will be `8` and the `little_square` caption will be `4`
