### PR TITLE
Allow styling of captions in SVG via layerOptions

### DIFF
--- a/packages/maker.js/src/core/svg.ts
+++ b/packages/maker.js/src/core/svg.ts
@@ -69,7 +69,7 @@ namespace MakerJs.exporter {
 
     /**
      * Convert a chain to SVG path data.
-     * 
+     *
      * @param chain Chain to convert.
      * @param offset IPoint relative offset point.
      * @param accuracy Optional accuracy of SVG path data.
@@ -166,7 +166,7 @@ namespace MakerJs.exporter {
 
     /**
      * Export a path to SVG path data.
-     * 
+     *
      * @param pathToExport IPath to export.
      * @param pathOffset IPoint relative offset of the path object.
      * @param exportOffset IPoint relative offset point of the export.
@@ -303,7 +303,7 @@ namespace MakerJs.exporter {
 
     /**
      * Renders an item in SVG markup.
-     * 
+     *
      * @param itemToExport Item to render: may be a path, an array of paths, or a model object.
      * @param options Rendering options object.
      * @param options.annotate Boolean to indicate that the id's of paths should be rendered as SVG text elements.
@@ -722,6 +722,7 @@ namespace MakerJs.exporter {
                 "x": center[0],
                 "y": center[1]
             });
+            addSvgAttrs(tag.attrs, colorLayerOptions(caption.layer));
             tag.innerText = caption.text;
             return tag.toString();
         });
@@ -782,7 +783,7 @@ namespace MakerJs.exporter {
         d.push(r, r);
         d.push(0);                   //0 = x-axis rotation
         d.push(largeArc ? 1 : 0);    //large arc=1, small arc=0
-        d.push(increasing ? 0 : 1);  //sweep-flag 0=increasing, 1=decreasing 
+        d.push(increasing ? 0 : 1);  //sweep-flag 0=increasing, 1=decreasing
         d.push(round(end[0], accuracy), round(end[1], accuracy));
     }
 
@@ -878,7 +879,7 @@ namespace MakerJs.exporter {
         flow?: IFlowAnnotation;
 
         /**
-         * Rendered reference origin. 
+         * Rendered reference origin.
          */
         origin?: IPoint;
 
@@ -888,7 +889,7 @@ namespace MakerJs.exporter {
         useSvgPathOnly?: boolean;
 
         /**
-         * Flag to use SVG viewbox. 
+         * Flag to use SVG viewbox.
          */
         viewBox?: boolean;
 

--- a/packages/maker.js/test/svg.js
+++ b/packages/maker.js/test/svg.js
@@ -57,4 +57,40 @@ describe('Export SVG', function () {
         assert.ok(svg.indexOf('xmlns="http://www.w3.org/2000/svg"') > 0);
     });
 
+    it('should export with layerOptions on caption text element', function () {
+        const exportOptions = {
+            fill: "green",
+            fontSize: '8pt',
+            stroke: "#333",
+            strokeWidth: "0.5mm",
+            layerOptions: {
+                square: {
+                    fill: "#999",
+                    cssStyle: "fill-opacity: 0.2",
+                },
+                square_caption: {
+                    stroke: "red",
+                },
+            },
+        };
+        var model = {};
+        makerjs
+            .$(new makerjs.models.Square(50))
+            .layer('square')
+            .addCaption('fold here', [0, 0], [50, 50])
+            .addTo(model, 'square');
+        model.models.square.caption.anchor.layer = "square_caption";
+        const svg = makerjs.exporter.toSVG(model, exportOptions);
+        const expected = [
+            '<svg width="50" height="50" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">',
+                '<g id="svgGroup" stroke-linecap="round" fill-rule="evenodd" font-size="8pt" stroke="#333" stroke-width="0.5mm" fill="green" style="stroke:#333;stroke-width:0.5mm;fill:green">',
+                    '<path d="M 0 50 L 50 50 L 50 0 L 0 0 L 0 50 Z" id="square" fill="#999" style="fill-opacity: 0.2" vector-effect="non-scaling-stroke"/>',
+                    '<g id="captions">',
+                        '<text alignment-baseline="middle" text-anchor="middle" transform="rotate(315,25,25)" x="25" y="25" stroke="red" style="stroke:red">fold here</text>',
+                    '</g>',
+                '</g>',
+            '</svg>'
+        ].join("");
+        assert.equal(svg, expected);
+    });
 });


### PR DESCRIPTION
## What does it do?
* Allows you to style a SVG `caption` using `layerOptions`
* Fixes #427 

## Example
```javascript
const exportOptions = {
  fill: "green",
  fontSize: '8pt',
  stroke: "#333",
  strokeWidth: "0.5mm",
  layerOptions: {
    square: {
      fill: "#999",
      cssStyle: "fill-opacity: 0.2",
    },
    square_caption: {
      stroke: "red",
    },
  },
};

var model = {};
makerjs
  .$(new makerjs.models.Square(50))
  .layer('square')
  .addCaption('fold here', [0, 0], [50, 50])
  .addTo(model, 'square');

const svg = makerjs.exporter.toSVG(model, exportOptions);
```

## Result
* The `big_square` caption will be `8` and the `little_square` caption will be `4`
```xml
<svg width="50" height="50" viewBox="0 0 50 50">
  <g id="svgGroup" stroke-linecap="round" fill-rule="evenodd" font-size="8pt" stroke="#333" stroke-width="0.5mm" fill="green" style="stroke:#333;stroke-width:0.5mm;fill:green">
    <path d="M 0 50 L 50 50 L 50 0 L 0 0 L 0 50 Z" id="square" fill="#999" style="fill-opacity: 0.2" vector-effect="non-scaling-stroke"/>
    <g id="captions">
      <text alignment-baseline="middle" text-anchor="middle" transform="rotate(315,25,25)" x="25" y="25" stroke="red" style="stroke:red">fold here</text>
    </g>
  </g>
</svg>
```
