### PR TITLE
support the captions layer in layerOptions

### DIFF
--- a/packages/maker.js/src/core/svg.ts
+++ b/packages/maker.js/src/core/svg.ts
@@ -729,6 +729,7 @@ namespace MakerJs.exporter {
 
         if (captionTags.length) {
             const captionGroup = new XmlTag('g', { "id": "captions" });
+            addSvgAttrs(captionGroup.attrs, colorLayerOptions(captionGroup.attrs.id));
             captionGroup.innerText = captionTags.join('');
             captionGroup.innerTextEscaped = true;
             append(captionGroup.toString());

--- a/packages/maker.js/test/svg.js
+++ b/packages/maker.js/test/svg.js
@@ -57,6 +57,24 @@ describe('Export SVG', function () {
         assert.ok(svg.indexOf('xmlns="http://www.w3.org/2000/svg"') > 0);
     });
 
+    it('should export with layerOptions on captions group', function () {
+        const exportOptions = {
+            layerOptions: {
+                captions: {
+                    fill: "#999",
+                    cssStyle: "fill-opacity: 0.2",
+                },
+            },
+        };
+        var model = {};
+        makerjs
+            .$(new makerjs.models.Square(50))
+            .addCaption('fold here', [0, 0], [50, 50])
+            .addTo(model, 'square');
+        const svg = makerjs.exporter.toSVG(model, exportOptions);
+        assert.ok(svg.indexOf('<g id="captions" fill="#999" style="fill-opacity: 0.2">') > 0);
+    });
+
     it('should export with layerOptions on caption text element', function () {
         const exportOptions = {
             fill: "green",


### PR DESCRIPTION
## What does it do?
* This allows you to style the `captions` layer using `layerOptions` in the `exportOptions`

## What else do you need to know?
* Currently:
  * when exporting to `SVG` all captions are put into a layer named `captions`.
  * you can set layerOptions at the top level `svg`.  
  * the `text` element for captions will be styled based on their parent model by default.
  * the `text` element can be put on it's own layer using the `anchor`
* The goal of this PR is to give you a place to apply a default style to all captions and then if needed override at individual levels.

## Example
```javascript
const exportOptions = {
  layerOptions: {
    captions: {
      fill: "#999",
      stroke: "black",
      strokeWidth: "0.10mm",
      cssStyle: "fill-opacity: 0.2",
    },
  },
};
var model = {};
makerjs
  .$(new makerjs.models.Square(50))
  .addCaption('fold here', [0, 0], [50, 50])
  .addTo(model, 'square');
const svg = makerjs.exporter.toSVG(model, exportOptions);
```
```xml
<svg width="50" height="50" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
  <g id="svgGroup" stroke-linecap="round" fill-rule="evenodd" font-size="9pt" stroke="#000" stroke-width="0.25mm" fill="none" style="stroke:#000;stroke-width:0.25mm;fill:none">
    <path d="M 0 50 L 50 50 L 50 0 L 0 0 L 0 50 Z" vector-effect="non-scaling-stroke"/>
    <g id="captions" stroke="black" stroke-width="0.10mm" fill="#999" style="fill-opacity: 0.2">
      <text alignment-baseline="middle" text-anchor="middle" transform="rotate(315,25,25)" x="25" y="25">fold here</text>
    </g>
  </g>
</svg>
```