### PR TITLE
add documentation about caption layersOptions on export

### DIFF
--- a/docs/_snippets/captions.html
+++ b/docs/_snippets/captions.html
@@ -3,7 +3,7 @@ title: Captions
 ---
 
 <p>
-    Captions are fragments of text that can be positioned anywhere in your model, 
+    Captions are fragments of text that can be positioned anywhere in your model,
     useful for adding documentation within your drawing.
     Captions are unlike the <a href="/docs/advanced-drawing/#Fonts%20and%20text">Text model</a>, which is a line drawing of glyphs in a given font.
 </p>
@@ -13,9 +13,10 @@ title: Captions
     The caption text is centered both horizontally and vertically at the center point of the anchor line.
     The text in a caption will not wrap, it is a single line of text.
     The text and anchor line do not need to be the same length, the anchor line is only used to determine the center point and the slope.
-    The anchor line may be rotated to angle the caption text. 
-    Anchor lines are moved, originated, scaled, distorted and rotated accoordingly within a model. 
+    The anchor line may be rotated to angle the caption text.
+    Anchor lines are moved, originated, scaled, distorted and rotated accoordingly within a model.
     The font size of caption text is determined when you export your model.
+    A caption can be put on a different <a href="/docs/intermediate-drawing/#Layers">layer</a> from it's model by setting the layer of it's anchor.
     Note: In the Playground, caption text does not scale when you zoom in or out.
 </p>
 
@@ -50,7 +51,7 @@ document.write(svg);
 <script>
     LiveDoc.evalLastCode();
 </script>
-    
+
 <p>
     There is a helper function <a href="/docs/api/modules/makerjs.model.html#addcaption">makerjs.model.addCaption(text, [optional] leftAnchorPoint, [optional] rightAnchorPoint)</a>
     which lets you add a caption on one line of code:
@@ -75,12 +76,12 @@ document.write(svg);
 <script>
     LiveDoc.evalLastCode();
 </script>
-    
+
 <p>
-    If the anchor line is degenerate (meaning its origin and end point are the same), you can achieve text 
+    If the anchor line is degenerate (meaning its origin and end point are the same), you can achieve text
     which will remain horizontally aligned regardless of model rotation:
 </p>
-    
+
 {% highlight javascript %}
 //add a caption that will not rotate
 

--- a/docs/_snippets/exporting-dxf.html
+++ b/docs/_snippets/exporting-dxf.html
@@ -8,18 +8,65 @@ title: DXF
     Call <code><a href="/docs/api/modules/makerjs.exporter.html#todxf">makerjs.exporter.toDXF</a>(model)</code> passing your model. This function returns a string of DXF.
 </p>
 
+<p>
+    If your drawing has layers with names that match the following reserved color names,
+    paths on that layer will have a stroke color automatically:
+    <br/>
+    aqua, black, blue, fuchsia, green, gray, lime, maroon, navy, olive, orange, purple, red, silver, teal, white, yellow
+</p>
+
+<h4>Captions</h4>
+
+<p>
+    A <a href="/docs/intermediate-drawing/#Captions">caption</a> will inherit the <code>layerOptions</code> that are applied to its model's layer name unless overridden by the anchor layer.
+</p>
+
 <h4>Advanced options</h4>
 
 <p>
-    Call <code><a href="/docs/api/modules/makerjs.exporter.html#todxf">makerjs.exporter.toDXF</a>(model, options)</code> passing your model and an options object.
+    You may override the default export behavior by calling <code><a href="/docs/api/modules/makerjs.exporter.html#todxf">makerjs.exporter.toDXF</a>(model, options)</code> and passing an options object.
     The options object has these properties:
 
-    <ul>
-        <li>
-            <a href="/docs/api/interfaces/makerjs.exporter.idxfrenderoptions.html#units">units</a> - <a href="/docs/api/index.html#unittype">Maker.js unit type</a> (default - extracted from drawing. If unit system is not in drawing or not passed, it will use DXF default of inches)
-        </li>
-        <li>
-            <a href="/docs/api/interfaces/makerjs.exporter.idxfrenderoptions.html#fontsize">fontSize</a> - (default - 9) font size of captions.
-        </li>
-    </ul>
+    <table>
+        <tr>
+            <th>property</th>
+            <th>values / effects</th>
+        </tr>
+        <tr>
+            <td><a href="/docs/api/interfaces/makerjs.exporter.idxfrenderoptions.html#units">units</a></td>
+            <td>
+                <a href="/docs/api/index.html#unittype">Maker.js unit type</a> - unit system (default: extracted from drawing. If unit system is not in drawing or not passed, it will use DXF default of inches)
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/docs/api/interfaces/makerjs.exporter.idxfrenderoptions.html#fontsize">fontSize</a></td>
+            <td>
+                number - font size of captions (default: 9).  The font size is in the same unit system as the <code>units</code> property.
+            </td>
+        </tr>
+        <tr>
+            <td><a href="/docs/api/interfaces/makerjs.exporter.idxfrenderoptions.html#layeroptions">layerOptions</a></td>
+            <td>
+                object map - keys are the layer names, values are an object with these properties:
+                <table>
+                    <tr>
+                        <th>property</th>
+                        <th>values</th>
+                    </tr>
+                    <tr>
+                        <td><a href="/docs/api/interfaces/makerjs.exporter.idxflayeroptions.html#color">color</a></td>
+                        <td>
+                            number - <a href="/docs/api/modules/makerjs.exporter.html#colors">Maker.js color</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><a href="/docs/api/interfaces/makerjs.exporter.idxflayeroptions.html#fontsize">fontSize</a></td>
+                        <td>
+                            number - font size of captions.  The font size is in the same unit system as the <code>units</code> property.
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
 </p>

--- a/docs/_snippets/exporting-svg.html
+++ b/docs/_snippets/exporting-svg.html
@@ -15,6 +15,14 @@ title: SVG
     aqua, black, blue, fuchsia, green, gray, lime, maroon, navy, olive, orange, purple, red, silver, teal, white, yellow
 </p>
 
+<h4>Captions</h4>
+
+<p>
+    <a href="/docs/intermediate-drawing/#Captions">Captions</a> are added to an SVG group with a layer name of "captions".
+    This layer name may be used to apply <code>layerOptions</code> that are common to all captions.
+    In addition, a caption will inherit the <code>layerOptions</code> that are applied to its model's layer name unless overridden by the anchor layer.
+</p>
+
 <h4>Advanced options</h4>
 
 <p>


### PR DESCRIPTION
## What does this do?
* Updates documentation about `captions`, `layers`, and `layerOptions`

## Screenshots
* /docs/intermediate-drawing/#Captions
![image](https://user-images.githubusercontent.com/6631628/62989290-ab06b180-be04-11e9-9468-3697fd7eed5b.png)

* /docs/exporting/#content
![image](https://user-images.githubusercontent.com/6631628/62989394-f8831e80-be04-11e9-9160-69957017a83b.png)

![image](https://user-images.githubusercontent.com/6631628/62989457-4009aa80-be05-11e9-9468-810ebb930b09.png)

