### PR TITLE
Turned typings listed as dependencies into devDependencies.

### DIFF
--- a/packages/maker.js/package.json
+++ b/packages/maker.js/package.json
@@ -96,15 +96,15 @@
   "devDependencies": {
     "@jscad/csg": "^0.3.7",
     "@jscad/stl-serializer": "^0.1.0",
+    "@types/bezier-js": "^0.0.6",
     "@types/graham_scan": "^1.0.28",
+    "@types/node": "^7.0.5",
+    "@types/opentype.js": "^0.7.0",
+    "@types/pdfkit": "^0.7.34",
     "dxf-parser-typings": "^1.3.0"
   },
   "dependencies": {
     "@danmarshall/jscad-typings": "^1.0.0",
-    "@types/bezier-js": "^0.0.6",
-    "@types/node": "^7.0.5",
-    "@types/opentype.js": "^0.7.0",
-    "@types/pdfkit": "^0.7.34",
     "bezier-js": "^2.1.0",
     "clone": "^1.0.2",
     "graham_scan": "^1.0.4",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -10,9 +10,11 @@
   "author": "Dan Marshall",
   "license": "Apache-2.0",
   "dependencies": {
+    "makerjs": "*"
+  },
+  "devDependencies": {
     "@types/codemirror": "0.0.38",
     "@types/marked": "^0.0.28",
-    "@types/opentype.js": "^0.7.0",
-    "makerjs": "*"
+    "@types/opentype.js": "^0.7.0"
   }
 }


### PR DESCRIPTION
Typings usually don't need to be installed by the end user. I didn't find any hint towards them actually being used in the code, so we can keep these 368 KB from being downloaded in production.