### PR TITLE
Rotate slope for y comparison

### DIFF
--- a/packages/maker.js/src/core/equal.ts
+++ b/packages/maker.js/src/core/equal.ts
@@ -194,18 +194,26 @@
             return round(slopeA.line.origin[0] - slopeB.line.origin[0]) == 0;
         }
 
-        //lines are parallel, but not vertical, see if y-intercept is the same
-        //scale the intercepts to a uniform range first to make sure that the
-        //larger distances don't disproportionately affect their difference
-        let factor = 1
-        if (Math.abs(slopeA.yIntercept) > 1) {
-            factor = 1 / slopeA.yIntercept
-        }
-        if (factor === 1 && Math.abs(slopeB.yIntercept) > 1) {
-            factor = 1 / slopeB.yIntercept
-        }
+        //lines are parallel, but not vertical
 
-        return round(factor * slopeA.yIntercept - factor * slopeB.yIntercept, .00001) == 0;
+        //rotate both to flat
+        const pA = yInterceptFromTranslateSlopeToZero(slopeA);
+        const pB = yInterceptFromTranslateSlopeToZero(slopeB);
+
+        //see if y-intercept is the same
+        return round(pA[1] - pB[1], .00001) == 0;
+    }
+
+    /**
+     * @private
+     */
+    function yInterceptFromTranslateSlopeToZero(s: ISlope): IPoint {
+        const yInterceptPoint: IPoint = [0, s.yIntercept];
+        if (s.slope === 0) {
+            return yInterceptPoint;
+        }
+        const a = angle.toDegrees(Math.atan(s.slope));
+        return point.rotate(yInterceptPoint, -a);
     }
 
     /**

--- a/packages/maker.js/src/core/equal.ts
+++ b/packages/maker.js/src/core/equal.ts
@@ -195,7 +195,11 @@
         }
 
         //lines are parallel, but not vertical, see if y-intercept is the same
-        return round(slopeA.yIntercept - slopeB.yIntercept, .00001) == 0;
+        //scale the intercepts to a uniform range first to make sure that the
+        //larger distances don't disproportionately affect their difference
+        const factor = 100 / slopeA.yIntercept;
+
+        return round(100 - factor * slopeB.yIntercept, .00001) == 0;
     }
 
     /**

--- a/packages/maker.js/src/core/equal.ts
+++ b/packages/maker.js/src/core/equal.ts
@@ -197,9 +197,15 @@
         //lines are parallel, but not vertical, see if y-intercept is the same
         //scale the intercepts to a uniform range first to make sure that the
         //larger distances don't disproportionately affect their difference
-        const factor = 100 / slopeA.yIntercept;
+        let factor = 1
+        if (Math.abs(slopeA.yIntercept) > 1) {
+            factor = 1 / slopeA.yIntercept
+        }
+        if (factor === 1 && Math.abs(slopeB.yIntercept) > 1) {
+            factor = 1 / slopeB.yIntercept
+        }
 
-        return round(100 - factor * slopeB.yIntercept, .00001) == 0;
+        return round(factor * slopeA.yIntercept - factor * slopeB.yIntercept, .00001) == 0;
     }
 
     /**

--- a/packages/maker.js/src/core/equal.ts
+++ b/packages/maker.js/src/core/equal.ts
@@ -196,24 +196,26 @@
 
         //lines are parallel, but not vertical
 
-        //rotate both to flat
-        const pA = yInterceptFromTranslateSlopeToZero(slopeA);
-        const pB = yInterceptFromTranslateSlopeToZero(slopeB);
+        //create array of slopes
+        const slopes = [slopeA, slopeB];
+
+        //get angle of each line
+        const angles = slopes.map(s => angle.toDegrees(Math.atan(s.slope)));
+
+        //create an array of each line cloned
+        const lines = slopes.map(s => path.clone(s.line)) as IPathLine[];
+
+        //use the first line as the rotation origin
+        const origin = lines[0].origin;
+
+        //rotate each line to flat
+        lines.forEach((l, i) => path.rotate(l, -angles[i], origin));
+
+        //get average y-intercept of each line
+        const averageYs = lines.map(l => (l.origin[1] + l.end[1]) / 2);
 
         //see if y-intercept is the same
-        return round(pA[1] - pB[1], .00001) == 0;
-    }
-
-    /**
-     * @private
-     */
-    function yInterceptFromTranslateSlopeToZero(s: ISlope): IPoint {
-        const yInterceptPoint: IPoint = [0, s.yIntercept];
-        if (s.slope === 0) {
-            return yInterceptPoint;
-        }
-        const a = angle.toDegrees(Math.atan(s.slope));
-        return point.rotate(yInterceptPoint, -a);
+        return round(averageYs[0] - averageYs[1], .00001) == 0;
     }
 
     /**
@@ -226,7 +228,6 @@
     export function isSlopeParallel(slopeA: ISlope, slopeB: ISlope): boolean {
 
         if (!slopeA.hasSlope && !slopeB.hasSlope) {
-
             return true;
         }
 

--- a/packages/maker.js/test/measure.js
+++ b/packages/maker.js/test/measure.js
@@ -87,20 +87,23 @@ describe('Measure', function () {
         var line1 = new makerjs.paths.Line([0, 0], [5, 5]);
         var line2 = new makerjs.paths.Line([3, 3], [7, 7]);
         var line3 = new makerjs.paths.Line([8, 8], [8, 0]);
+        var line4 = new makerjs.paths.Line([8, 8], [9, 9.00001]);
         var slope1 = makerjs.measure.lineSlope(line1);
         var slope2 = makerjs.measure.lineSlope(line2);
         var slope3 = makerjs.measure.lineSlope(line3);
+        var slope4 = makerjs.measure.lineSlope(line4);
         assert.ok(makerjs.measure.isSlopeEqual(slope1, slope2));
         assert.ok(!makerjs.measure.isSlopeEqual(slope1, slope3));
+        assert.ok(!makerjs.measure.isSlopeEqual(slope1, slope4));
     });
 
     it('should find approximately equal slopes', function () {
         var line1 = new makerjs.paths.Line([1, 0], [2, 2]);
-        var line2 = new makerjs.paths.Line([1, 0], [2, 2.000000001]);
+        var line2 = new makerjs.paths.Line([1, 0], [2, 2.000001]);
         var slope1 = makerjs.measure.lineSlope(line1);
         var slope2 = makerjs.measure.lineSlope(line2);
-        var translated1 = makerjs.path.moveRelative(line1, [10000, 0])
-        var translated2 = makerjs.path.moveRelative(line2, [10000, 0])
+        var translated1 = makerjs.path.moveRelative(line1, [100000, 0])
+        var translated2 = makerjs.path.moveRelative(line2, [100000, 0])
         var slope3 = makerjs.measure.lineSlope(translated1);
         var slope4 = makerjs.measure.lineSlope(translated2);
         assert.ok(makerjs.measure.isSlopeEqual(slope1, slope2));

--- a/packages/maker.js/test/measure.js
+++ b/packages/maker.js/test/measure.js
@@ -96,7 +96,7 @@ describe('Measure', function () {
 
     it('should find approximately equal slopes', function () {
         var line1 = new makerjs.paths.Line([1, 0], [2, 2]);
-        var line2 = new makerjs.paths.Line([1, 0], [2, 2.000001]);
+        var line2 = new makerjs.paths.Line([1, 0], [2, 2.000000001]);
         var slope1 = makerjs.measure.lineSlope(line1);
         var slope2 = makerjs.measure.lineSlope(line2);
         var translated1 = makerjs.path.moveRelative(line1, [10000, 0])

--- a/packages/maker.js/test/measure.js
+++ b/packages/maker.js/test/measure.js
@@ -94,6 +94,19 @@ describe('Measure', function () {
         assert.ok(!makerjs.measure.isSlopeEqual(slope1, slope3));
     });
 
+    it('should find approximately equal slopes', function () {
+        var line1 = new makerjs.paths.Line([1, 0], [2, 2]);
+        var line2 = new makerjs.paths.Line([1, 0], [2, 2.000001]);
+        var slope1 = makerjs.measure.lineSlope(line1);
+        var slope2 = makerjs.measure.lineSlope(line2);
+        var translated1 = makerjs.path.moveRelative(line1, [10000, 0])
+        var translated2 = makerjs.path.moveRelative(line2, [10000, 0])
+        var slope3 = makerjs.measure.lineSlope(translated1);
+        var slope4 = makerjs.measure.lineSlope(translated2);
+        assert.ok(makerjs.measure.isSlopeEqual(slope1, slope2));
+        assert.ok(makerjs.measure.isSlopeEqual(slope3, slope4));
+    });
+
     it('should find point on a slope', function () {
         var line = new makerjs.paths.Line([0, 0], [5, 5]);
         var slope = makerjs.measure.lineSlope(line);


### PR DESCRIPTION
@mrzealot - based on your issue, I had the idea to do a rotate translation of slopes so that the slope is flat, and we can compare the y components easily.

Fixes #465 