### PR TITLE
fix a crashing bug in export toPDF

### DIFF
--- a/packages/maker.js/src/core/pdf.ts
+++ b/packages/maker.js/src/core/pdf.ts
@@ -43,7 +43,7 @@
         var left = -size.low[0];
         var offset: IPoint = [left, size.high[1]];
 
-        offset = point.add(offset, options.origin);
+        offset = point.add(offset, opts.origin);
 
         model.findChains(
             scaledModel,


### PR DESCRIPTION
options is an optional parameter, and it extends a local variable called opts. opts is the one that need to be used later in the code.