### PR TITLE
Don't return undefined when an empty model is passed to makerjs.measure.modelExtents

### DIFF
--- a/packages/maker.js/src/core/measure.ts
+++ b/packages/maker.js/src/core/measure.ts
@@ -491,7 +491,7 @@ namespace MakerJs.measure {
      * @param atlas Optional atlas to save measurements.
      * @returns object with low and high points.
      */
-    export function modelExtents(modelToMeasure: IModel, atlas?: Atlas): IMeasureWithCenter {
+    export function modelExtents(modelToMeasure: IModel, atlas?: Atlas): IMeasureWithCenter | null {
 
         function increaseParentModel(childRoute: string[], childMeasurement: IMeasure) {
 
@@ -537,7 +537,7 @@ namespace MakerJs.measure {
             return augment(m);
         }
 
-        return m;
+        return null;
     }
 
 


### PR DESCRIPTION
Currently `makerjs.measure.modelExtents({ models: {} })` returns `undefined` which makes code prone to NPE's

This PR updates `modelExtents` to instead return an empty `IMeasureWithCenter ` object: `{ height: 0, width: 0, center: null, low: null, high: null }`